### PR TITLE
公開範囲の設定を削除

### DIFF
--- a/source/new.php
+++ b/source/new.php
@@ -1,54 +1,6 @@
 <!DOCTYPE html>
 <?php 
- /*   $banarr = array(
-        ",","\"","'",".","`","~","$","%","&","*","(",")","{","}","\\","/"
-    );
-    $banfl = false;
-    $err_titmes = '';
-    $err_passmes = '';
-
-    if($_SERVER['REQUEST_METHOD'] == 'POST') {
-        if(!empty($_POST['title'])) {
-            $title = str_split($_POST['title']);
-            foreach($title as $value) {
-                foreach($banarr as $banchar) {
-                    if(strcmp($value, $banchar) == 0) {
-                        $err_titmes = 'E01:タイトルには使用できない文字が含まれています。';
-                        $banfl = true;
-                        break;
-                    }
-                }
-                if($banfl) {
-                    break;
-                }
-           }
-        }
-        else {
-            $err_titmes = 'E02:タイトルは必須項目です。';
-        }
-
-        if(!empty($_POST['password'])) {
-            $pass = str_split($_POST['password']);
-            if(count($pass) < 6) {
-                $err_passmes = 'E03:パスワードは少なくとも6文字以上でないといけません。';
-            }
-            foreach($pass as $value) {
-                foreach($banarr as $banchar) {
-                    if(strcmp($value, $banchar) == 0) {
-                        $err_passmes = 'E04:パスワードには使用できない文字が含まれています。';
-                        $banfl = true;
-                        break;
-                    }
-                }
-                if($banfl) {
-                    break;
-                }
-            }
-        }
-        else {
-            $err_passmes = 'E05:パスワードは必須項目です。';
-        }
-    }*/
+    /**/ 
 ?>
 
 <html lang="ja">
@@ -94,16 +46,8 @@
                     <?php echo $err_titmes ?>
                 </div>
                 <div class="newthr">
-                    <h3><label for="checkrange">公開範囲 : </label></h3>
-                    <div class="ispublic">
-                        <input type="radio" name="ispublic" title="スレッドを全体に公開します"　onClick="ispublic_check1(this.checked)" checked >全体公開</input>
-                        <input type="radio" name="ispublic" title="スレッドを指定した範囲にのみ公開します" onClick="ispublic_check2(this.checked)">限定公開</input>
-                    </div>
-                </div>
-                <div class="newthr">
-                    <h3><label for="password">管理者パスワード : </h3></label>
-                    <input id="pass" type="password" name="password" title="半角英数字6~15文字以内" maxlength="15" pattern="([0-9a-zA-Z]{6,15})" disabled required>
-                    <?php echo $err_passmes ?>
+                    <h3><label for="password">管理用パスワード : </h3></label>
+                    <input id="pass" type="password" name="password" title="半角英数字6~15文字以内" maxlength="15" pattern="([0-9a-zA-Z]{6,15})" required>
                 </div>
                 <div class="newthr">
                     <h3><label for="comment">内容 : </label></h3>


### PR DESCRIPTION
主な変更
- 新規スレッド作成ページにおいて、公開範囲を選択するラジオボタンを削除
- これに伴って、管理者パスワードのdisable属性を削除
- 管理者パスワードの名称を管理用パスワードに変更

細かい変更
- これまでphpで書いていたコードの大半をhtmlで書き換え
- これに伴い、php部分のコードを削除